### PR TITLE
Fix S3 paths

### DIFF
--- a/.mocharc.perf.yaml
+++ b/.mocharc.perf.yaml
@@ -1,9 +1,0 @@
-# Required to run benchmark
-require:
-  - ts-node/register
-  - src/mochaPlugin/mochaPlugin.ts
-reporter: src/mochaPlugin/reporter.ts
-# Extra props
-colors: true
-timeout: 5000
-exit: true

--- a/src/history/s3.ts
+++ b/src/history/s3.ts
@@ -174,7 +174,7 @@ export class S3HistoryProvider implements IHistoryProvider {
   }
 
   private getLatestInBranchKey(branch: string): string {
-    return path.join(latestDir, branch);
+    return path.join(this.config.keyPrefix, latestDir, branch);
   }
 
   private getHistoryCommitKey(commitSha: string): string {

--- a/test/history/s3.test.ts
+++ b/test/history/s3.test.ts
@@ -5,13 +5,32 @@ import {S3HistoryProvider} from "../../src/history/s3";
 import dotenv from "dotenv";
 dotenv.config();
 
-// Currently fails with
-//
-// Error: reserveCache failed: Cache Service Url not found, unable to restore cache
-//
-// See:
-//  - https://github.com/nektos/act/issues/329
-//  - https://github.com/nektos/act/issues/285
+describe("benchmark history S3 paths", () => {
+  const Bucket = "myproject-benchmark-data";
+  const keyPrefix = "myorg/myproject/Linux";
+
+  let historyProvider: S3HistoryProvider;
+  before(() => {
+    historyProvider = new S3HistoryProvider({Bucket, keyPrefix});
+  });
+
+  it("getLatestInBranchKey", () => {
+    const branch = "master";
+    expect(historyProvider["getLatestInBranchKey"](branch)).to.equal("myorg/myproject/Linux/latest/master");
+  });
+
+  it("getHistoryCommitKey", () => {
+    const commit = "9de601df50796e6a4bdedfd1ba515bb8a02b71e8";
+    expect(historyProvider["getHistoryCommitKey"](commit)).to.equal(
+      "myorg/myproject/Linux/history/9de601df50796e6a4bdedfd1ba515bb8a02b71e8"
+    );
+  });
+
+  it("getHistoryDir", () => {
+    expect(historyProvider["getHistoryDir"]()).to.equal("myorg/myproject/Linux/history");
+  });
+});
+
 describe.skip("benchmark history S3", function () {
   this.timeout(60 * 1000);
 


### PR DESCRIPTION
**Motivation**

Not prepending with prefixKey may lead to data loss if multiple projects share the same bucket

**Description**

Prepend all S3 paths with prefixKey