### PR TITLE
Add before hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "mocha test/**/*.test.ts",
     "lint": "eslint --color --ext .ts src/ test/",
     "prepublishOnly": "yarn build",
-    "benchmark": "node -r ts-node/register src/cli.ts 'test/**/*.perf.ts'"
+    "benchmark": "node -r ts-node/register src/cli.ts 'test/perf/**/*.test.ts'"
   },
   "devDependencies": {
     "@types/chai": "^4.2.19",

--- a/src/mochaPlugin/format.ts
+++ b/src/mochaPlugin/format.ts
@@ -1,36 +1,10 @@
 /* eslint-disable no-console */
 
-export type BenchmarkOpts = {
-  runs?: number;
-  maxMs?: number;
-  minMs?: number;
-};
-
-export type BenchmarkRunOpts = BenchmarkOpts & {
-  id: string;
-};
-
-export type BenchmarkRunOptsWithFn<T> = BenchmarkOpts & {
-  id: string;
-  fn: (arg: T) => void | Promise<void>;
-  beforeEach?: (i: number) => T | Promise<T>;
-};
-
 export type BenchmarkResult = {
   id: string;
   averageNs: number;
   runsDone: number;
   totalMs: number;
-};
-
-export type BenchmarkResultCompared = BenchmarkResult & {
-  ratio: number | null;
-  isFailed: boolean;
-  isBetter: boolean;
-};
-
-export type BenchmarkResultDetail = {
-  runsNs: bigint[];
 };
 
 export function formatResultRow(

--- a/src/mochaPlugin/index.ts
+++ b/src/mochaPlugin/index.ts
@@ -11,10 +11,13 @@ const optsMap = new Map<Mocha.Suite, BenchmarkOpts>();
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
-export function itBench<T>(opts: BenchmarkRunOptsWithFn<T>): void;
-export function itBench<T>(idOrOpts: string | Omit<BenchmarkRunOptsWithFn<T>, "fn">, fn: (arg: T) => void): void;
-export function itBench<T>(
-  idOrOpts: string | PartialBy<BenchmarkRunOptsWithFn<T>, "fn">,
+export function itBench<T, T2>(opts: BenchmarkRunOptsWithFn<T, T2>): void;
+export function itBench<T, T2>(
+  idOrOpts: string | Omit<BenchmarkRunOptsWithFn<T, T2>, "fn">,
+  fn: (arg: T) => void
+): void;
+export function itBench<T, T2>(
+  idOrOpts: string | PartialBy<BenchmarkRunOptsWithFn<T, T2>, "fn">,
   fn?: (arg: T) => void | Promise<void>
 ): void {
   // TODO:
@@ -24,7 +27,7 @@ export function itBench<T>(
   // if (this.averageNs === null) this.averageNs = result.averageNs;
   // result.factor = result.averageNs / this.averageNs;
 
-  let opts: BenchmarkRunOptsWithFn<T>;
+  let opts: BenchmarkRunOptsWithFn<T, T2>;
   if (typeof idOrOpts === "string") {
     if (!fn) throw Error("fn arg must be set");
     opts = {id: idOrOpts, fn};
@@ -32,7 +35,7 @@ export function itBench<T>(
     if (fn) {
       opts = {...idOrOpts, fn};
     } else {
-      const optsWithFn = idOrOpts as BenchmarkRunOptsWithFn<T>;
+      const optsWithFn = idOrOpts as BenchmarkRunOptsWithFn<T, T2>;
       if (!optsWithFn.fn) throw Error("opts.fn arg must be set");
       opts = optsWithFn;
     }

--- a/test/perf/iteration.test.ts
+++ b/test/perf/iteration.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import {itBench, setBenchOpts} from "../src";
+import {itBench, setBenchOpts} from "../../src";
 
 // As of Jun 17 2021
 // Compare state root
@@ -38,5 +38,32 @@ describe("Array iteration", () => {
     // Uncomment below to cause a guaranteed performance regression
     // arr.reduce((total, curr) => total + curr, 0);
     // arr.reduce((total, curr) => total + curr, 0);
+  });
+
+  // Test before and beforeEach hooks
+
+  itBench({
+    id: "sum array with reduce beforeEach",
+    beforeEach: () => Array.from({length: 1e4}, (_, i) => i),
+    fn: () => {
+      arr.reduce((total, curr) => total + curr, 0);
+
+      // Uncomment below to cause a guaranteed performance regression
+      // arr.reduce((total, curr) => total + curr, 0);
+      // arr.reduce((total, curr) => total + curr, 0);
+    },
+  });
+
+  itBench({
+    id: "sum array with reduce before beforeEach",
+    before: () => Array.from({length: 1e4}, (_, i) => i),
+    beforeEach: (arr) => arr.slice(0),
+    fn: () => {
+      arr.reduce((total, curr) => total + curr, 0);
+
+      // Uncomment below to cause a guaranteed performance regression
+      // arr.reduce((total, curr) => total + curr, 0);
+      // arr.reduce((total, curr) => total + curr, 0);
+    },
   });
 });


### PR DESCRIPTION
**Motivation**

Run once for itBench test. Very helpful to only compute very expensive data for that test and keep the scopes clean

**Description**

```ts
itBench({
    id: "sum array with reduce before beforeEach",
    before: () => Array.from({length: 1e4}, (_, i) => i),
    beforeEach: (arr) => arr.slice(0),
    fn: () => {
      arr.reduce((total, curr) => total + curr, 0);

      // Uncomment below to cause a guaranteed performance regression
      // arr.reduce((total, curr) => total + curr, 0);
      // arr.reduce((total, curr) => total + curr, 0);
    },
  });
```