### PR TITLE
Add .only and .skip support

### DIFF
--- a/src/mochaPlugin/runBenchFn.ts
+++ b/src/mochaPlugin/runBenchFn.ts
@@ -4,6 +4,9 @@ export type BenchmarkOpts = {
   runs?: number;
   maxMs?: number;
   minMs?: number;
+  // For mocha
+  only?: boolean;
+  skip?: boolean;
 };
 
 export type BenchmarkRunOpts = BenchmarkOpts & {

--- a/test/perf/iteration.test.ts
+++ b/test/perf/iteration.test.ts
@@ -66,4 +66,14 @@ describe("Array iteration", () => {
       // arr.reduce((total, curr) => total + curr, 0);
     },
   });
+
+  // Test mocha skip and only
+
+  itBench.skip("sum array with reduce", () => {
+    arr.reduce((total, curr) => total + curr, 0);
+  });
+
+  // itBench.only("sum array with reduce", () => {
+  //   arr.reduce((total, curr) => total + curr, 0);
+  // });
 });


### PR DESCRIPTION
**Motivation**

Very familiar and useful API that mocha users are used to.

**Description**

```ts
  itBench.skip("sum array with reduce", () => {
    arr.reduce((total, curr) => total + curr, 0);
  });

  itBench.only("sum array with reduce", () => {
    arr.reduce((total, curr) => total + curr, 0);
  });
```