### PR TITLE
Allow to customize threshold for each itBench

### DIFF
--- a/src/compare/compute.ts
+++ b/src/compare/compute.ts
@@ -15,6 +15,7 @@ export function computeBenchComparision(
   const results = currBench.results.map((currBench): ResultComparision => {
     const {id} = currBench;
     const prevBench = prevResults.get(id);
+    const thresholdBench = currBench.threshold ?? threshold;
 
     if (prevBench) {
       const ratio = currBench.averageNs / prevBench.averageNs;
@@ -23,8 +24,8 @@ export function computeBenchComparision(
         currAverageNs: currBench.averageNs,
         prevAverageNs: prevBench.averageNs,
         ratio,
-        isFailed: ratio > threshold,
-        isImproved: ratio < 1 / threshold,
+        isFailed: ratio > thresholdBench,
+        isImproved: ratio < 1 / thresholdBench,
       };
     } else {
       return {

--- a/src/mochaPlugin/reporter.ts
+++ b/src/mochaPlugin/reporter.ts
@@ -76,7 +76,7 @@ export function benchmarkReporterWithPrev(prevBench: Benchmark | null, threshold
             // Render benchmark
             const prevResult = prevResults.get(result.id) ?? null;
 
-            const resultRow = formatResultRow(result, prevResult, threshold);
+            const resultRow = formatResultRow(result, prevResult, result.threshold ?? threshold);
             const fmt = indent() + color("checkmark", "  " + symbols.ok) + " " + resultRow;
             consoleLog(fmt);
           } else {

--- a/src/mochaPlugin/runBenchFn.ts
+++ b/src/mochaPlugin/runBenchFn.ts
@@ -8,6 +8,11 @@ export type BenchmarkOpts = {
   only?: boolean;
   skip?: boolean;
   timeout?: number;
+  // For reporter
+  /** Customize the threshold for this specific benchmark. Set to Infinity to disable it */
+  threshold?: number;
+  /** Equivalent to setting threshold = Infinity */
+  noThreshold?: boolean;
 };
 
 export type BenchmarkRunOpts = BenchmarkOpts & {
@@ -56,7 +61,13 @@ export async function runBenchFn<T, T2>(
   const averageNs = Number(average);
 
   return {
-    result: {id: opts.id, averageNs, runsDone: i - 1, totalMs: Date.now() - startRunMs},
+    result: {
+      id: opts.id,
+      averageNs,
+      runsDone: i - 1,
+      totalMs: Date.now() - startRunMs,
+      threshold: opts.noThreshold === true ? Infinity : opts.threshold,
+    },
     runsNs,
   };
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -27,7 +27,8 @@ export const options: ICliCommandOptions<CliOpts> = {
     defaultDescription: "Infinity",
   },
   threshold: {
-    description: "Ratio of new average time per run vs previos time per run to consider a failure",
+    description:
+      "Ratio of new average time per run vs previos time per run to consider a failure. Set to 'Infinity' to disable it.",
     type: "number",
     default: optionsDefault.threshold,
   },

--- a/src/run.ts
+++ b/src/run.ts
@@ -13,6 +13,9 @@ import {isGaRun} from "./github/context";
 /* eslint-disable no-console */
 
 export async function run(opts: Opts): Promise<void> {
+  // Sanitize opts
+  if (isNaN(opts.threshold)) throw Error("opts.threshold is not a number");
+
   // Retrieve history
   const historyProvider = getHistoryProvider(opts);
   console.log(`Connected to historyProvider: ${historyProvider.providerInfo()}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export type BenchmarkResult = {
   averageNs: number;
   runsDone: number;
   totalMs: number;
+  // For reporter
+  threshold: number | undefined;
 };
 
 /** Time results for a single benchmark (all items) */

--- a/test/perf/iteration.test.ts
+++ b/test/perf/iteration.test.ts
@@ -76,4 +76,22 @@ describe("Array iteration", () => {
   // itBench.only("sum array with reduce", () => {
   //   arr.reduce((total, curr) => total + curr, 0);
   // });
+
+  // Reporter options
+
+  itBench({
+    id: "sum array with reduce high threshold",
+    threshold: 5,
+    fn: () => {
+      arr.reduce((total, curr) => total + curr, 0);
+    },
+  });
+
+  itBench({
+    id: "sum array with reduce no threshold",
+    threshold: Infinity,
+    fn: () => {
+      arr.reduce((total, curr) => total + curr, 0);
+    },
+  });
 });

--- a/test/unit/history/gaCache.test.ts
+++ b/test/unit/history/gaCache.test.ts
@@ -16,7 +16,7 @@ describe.skip("benchmark history gaCache", function () {
   const branch = "main";
   const benchmark: Benchmark = {
     commitSha: "010101010101010101010101",
-    results: [{id: "for loop", averageNs: 16573, runsDone: 1024, totalMs: 465}],
+    results: [{id: "for loop", averageNs: 16573, runsDone: 1024, totalMs: 465, threshold: 2}],
   };
 
   const cacheKey = "ga-cache-testing";

--- a/test/unit/history/local.test.ts
+++ b/test/unit/history/local.test.ts
@@ -8,7 +8,7 @@ describe("benchmark history local", () => {
   const branch = "main";
   const benchmark: Benchmark = {
     commitSha: "010101010101010101010101",
-    results: [{id: "for loop", averageNs: 16573, runsDone: 1024, totalMs: 465}],
+    results: [{id: "for loop", averageNs: 16573, runsDone: 1024, totalMs: 465, threshold: 2}],
   };
 
   const testDir = fs.mkdtempSync("test_files_");

--- a/test/unit/history/s3.test.ts
+++ b/test/unit/history/s3.test.ts
@@ -37,7 +37,7 @@ describe.skip("benchmark history S3", function () {
   const branch = "main";
   const benchmark: Benchmark = {
     commitSha: "010101010101010101010101",
-    results: [{id: "for loop", averageNs: 16573, runsDone: 1024, totalMs: 465}],
+    results: [{id: "for loop", averageNs: 16573, runsDone: 1024, totalMs: 465, threshold: 2}],
   };
 
   let historyProvider: S3HistoryProvider;


### PR DESCRIPTION
**Motivation**

Some benchmarks might be more unstable than others. This option allows to fine tune or disable threshold comparisons that fail CI runs.

**Description**

```ts
  itBench({
    id: "sum array with reduce high threshold",
    threshold: 5,
    fn: () => {
      arr.reduce((total, curr) => total + curr, 0);
    },
  });
```