### PR TITLE
Improve API to decide when to stop the benchmark

### DIFF
--- a/src/mochaPlugin/index.ts
+++ b/src/mochaPlugin/index.ts
@@ -54,15 +54,17 @@ const itBenchFn: ItBenchFn = function itBench<T, T2>(
       }
     }
 
-    const {result, runsNs} = await runBenchFn(opts);
+    // Persist full results if requested. dir is created in `beforeAll`
+    const benchmarkResultsCsvDir = process.env.BENCHMARK_RESULTS_CSV_DIR;
+    const persistRunsNs = Boolean(benchmarkResultsCsvDir);
+
+    const {result, runsNs} = await runBenchFn(opts, persistRunsNs);
 
     // Store result for:
     // - to persist benchmark data latter
     // - to render with the custom reporter
     results.set(opts.id, result);
 
-    // Persist full results if requested. dir is created in `beforeAll`
-    const benchmarkResultsCsvDir = process.env.BENCHMARK_RESULTS_CSV_DIR;
     if (benchmarkResultsCsvDir) {
       fs.mkdirSync(benchmarkResultsCsvDir, {recursive: true});
       const filename = `${result.id}.csv`;

--- a/src/mochaPlugin/runBenchFn.ts
+++ b/src/mochaPlugin/runBenchFn.ts
@@ -36,7 +36,8 @@ export type BenchmarkRunOptsWithFn<T, T2> = BenchmarkOpts & {
 };
 
 export async function runBenchFn<T, T2>(
-  opts: BenchmarkRunOptsWithFn<T, T2>
+  opts: BenchmarkRunOptsWithFn<T, T2>,
+  persistRunsNs?: boolean
 ): Promise<{result: BenchmarkResult; runsNs: bigint[]}> {
   const minRuns = opts.minRuns || 1;
   const maxRuns = opts.maxRuns || Infinity;
@@ -84,7 +85,8 @@ export async function runBenchFn<T, T2>(
       // Persist results
       runIdx += 1;
       totalNs += runNs;
-      runsNs.push(runNs);
+      // If the caller wants the exact times of all runs, persist them
+      if (persistRunsNs) runsNs.push(runNs);
 
       // When is a good time to stop a benchmark? A naive answer is after N miliseconds or M runs.
       // This code aims to stop the benchmark when the average fn run time has converged at a value

--- a/src/mochaPlugin/runBenchFn.ts
+++ b/src/mochaPlugin/runBenchFn.ts
@@ -1,9 +1,18 @@
 import {BenchmarkResult} from "../types";
 
 export type BenchmarkOpts = {
-  runs?: number;
+  /** Max number of fn() runs, after which the benchmark stops */
+  maxRuns?: number;
+  /** Min number of fn() runs before considering stopping the benchmark after converging */
+  minRuns?: number;
+  /** Max total miliseconds of runs, after which the benchmark stops */
   maxMs?: number;
+  /** Min total miiliseconds of runs before considering stopping the benchmark after converging */
   minMs?: number;
+  /** Minimum real benchmark function run time before starting to count towards results. Set to 0 to not warm-up */
+  warmUpMs?: number;
+  /** Convergance factor (0,1) at which the benchmark automatically stops. Set to 1 to disable */
+  convergeFactor?: number;
   // For mocha
   only?: boolean;
   skip?: boolean;
@@ -29,50 +38,103 @@ export type BenchmarkRunOptsWithFn<T, T2> = BenchmarkOpts & {
 export async function runBenchFn<T, T2>(
   opts: BenchmarkRunOptsWithFn<T, T2>
 ): Promise<{result: BenchmarkResult; runsNs: bigint[]}> {
-  const runs = opts.runs || 512;
-  const maxMs = opts.maxMs || 2000;
+  const minRuns = opts.minRuns || 1;
+  const maxRuns = opts.maxRuns || Infinity;
+  const maxMs = opts.maxMs || Infinity;
   const minMs = opts.minMs || 100;
+  const warmUpMs = opts.warmUpMs !== undefined ? opts.warmUpMs : 500;
+  const convergeFactor = opts.convergeFactor || 0.5 / 100; // 0.5%
+  const warmUpNs = BigInt(warmUpMs) * BigInt(1e6);
+  const sampleEveryMs = 100;
 
   const runsNs: bigint[] = [];
-
   const startRunMs = Date.now();
-  let i = 0;
+
+  let runIdx = 0;
+  let totalNs = BigInt(0);
+  let totalWarmUpNs = BigInt(0);
+  let prevAvg0 = 0;
+  let prevAvg1 = 0;
+  let lastConvergenceSample = startRunMs;
 
   const inputAll = opts.before ? await opts.before() : (undefined as unknown as T2);
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
     const ellapsedMs = Date.now() - startRunMs;
-    // Exceeds time limit, stop
-    if (ellapsedMs > maxMs) break;
-    // Exceeds target runs + min time
-    if (i++ >= runs && ellapsedMs > minMs) break;
+    const mustStop = ellapsedMs >= maxMs || runIdx >= maxRuns;
+    const mayStop = ellapsedMs > minMs && runIdx > minRuns;
+    // Exceeds limits, must stop now
+    if (mustStop) {
+      break;
+    }
 
-    const input = opts.beforeEach ? await opts.beforeEach(inputAll, i) : (undefined as unknown as T);
+    const input = opts.beforeEach ? await opts.beforeEach(inputAll, runIdx) : (undefined as unknown as T);
 
     const startNs = process.hrtime.bigint();
     await opts.fn(input);
     const endNs = process.hrtime.bigint();
 
-    runsNs.push(endNs - startNs);
+    const runNs = endNs - startNs;
+
+    if (totalWarmUpNs < warmUpNs) {
+      // Warm-up, do not count towards results
+      totalWarmUpNs += runNs;
+    } else {
+      // Persist results
+      runIdx += 1;
+      totalNs += runNs;
+      runsNs.push(runNs);
+
+      // When is a good time to stop a benchmark? A naive answer is after N miliseconds or M runs.
+      // This code aims to stop the benchmark when the average fn run time has converged at a value
+      // within a given convergence factor. To prevent doing expensive math to often for fast fn,
+      // it only takes samples every `sampleEveryMs`. It stores two past values to be able to compute
+      // a very rough linear and quadratic convergence.
+      if (Date.now() - lastConvergenceSample > sampleEveryMs) {
+        lastConvergenceSample = Date.now();
+        const avg = Number(totalNs / BigInt(runIdx));
+
+        // Compute convergence (1st order + 2nd order)
+        const a = prevAvg0;
+        const b = prevAvg1;
+        const c = avg;
+
+        // Only do convergence math if it may stop
+        if (mayStop) {
+          // Aprox linear convergence
+          const convergence1 = Math.abs(c - a);
+          // Aprox quadratic convergence
+          const convergence2 = Math.abs(b - (a + c) / 2);
+          // Take the greater of both to enfore linear and quadratic are below convergeFactor
+          const convergence = Math.max(convergence1, convergence2) / a;
+
+          // Okay to stop + has converged, stop now
+          if (convergence < convergeFactor) {
+            break;
+          }
+        }
+
+        prevAvg0 = prevAvg1;
+        prevAvg1 = avg;
+      }
+    }
   }
 
-  const average = averageBigint(runsNs);
-  const averageNs = Number(average);
+  if (runIdx === 0) {
+    throw Error("No run was completed in time");
+  }
+
+  const averageNs = totalNs / BigInt(runIdx);
 
   return {
     result: {
       id: opts.id,
-      averageNs,
-      runsDone: i - 1,
+      averageNs: Number(averageNs),
+      runsDone: runIdx - 1,
       totalMs: Date.now() - startRunMs,
       threshold: opts.noThreshold === true ? Infinity : opts.threshold,
     },
     runsNs,
   };
-}
-
-function averageBigint(arr: bigint[]): bigint {
-  const total = arr.reduce((total, value) => total + value);
-  return total / BigInt(arr.length);
 }

--- a/test/perf/iteration.test.ts
+++ b/test/perf/iteration.test.ts
@@ -9,12 +9,7 @@ import {itBench, setBenchOpts} from "../../src";
 // byteArrayEquals with valueOf()                                         853971.0 ops/s      1.171000 us/op 9963051 runs    16.07 s
 
 describe("Array iteration", () => {
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    // This bench is very fast, with 1s it can do 300k runs
-    minMs: 0.5 * 1000,
-    runs: 128,
-  });
+  setBenchOpts({maxMs: 60 * 1000, convergeFactor: 0.1 / 100});
 
   it("Regular test", () => {
     assert.strictEqual(1 + 2, 3);


### PR DESCRIPTION
**Motivation**

Providing a minimum number of runs and miliseconds to run a benchmark was not a great UX. It's more important to tell the benchmark tool to keep running until results converge enough.

**Description**

Compute a convergence factor to decide when to stop the benchmark.

API has a breaking change, `runs` is no longer a valid option. See:

https://github.com/dapplion/benchmark/blob/89364680050beebf905c0ec8d783be12fc4612a6/src/mochaPlugin/runBenchFn.ts#L3-L12